### PR TITLE
fix: docs & image model handling

### DIFF
--- a/internal/api/model.go
+++ b/internal/api/model.go
@@ -40,20 +40,23 @@ func (h *Handler) getOrSetModel(model string) (res alexa.Response, err error) {
 		return
 	case chatmodels.IMAGE_MODEL_STABLE_DIFFUSION.String():
 		h.ImageModel = chatmodels.IMAGE_MODEL_STABLE_DIFFUSION
-		res = alexa.NewResponse("Chat Models", "ok", false)
+		res = alexa.NewResponse("Image Models", "ok", false)
+		return
 	case chatmodels.IMAGE_MODEL_DALL_E_3.String():
 		h.ImageModel = chatmodels.IMAGE_MODEL_DALL_E_3
-		res = alexa.NewResponse("Chat Models", "ok", false)
+		res = alexa.NewResponse("Image Models", "ok", false)
+		return
 	case chatmodels.IMAGE_MODEL_DALL_E_2.String():
 		h.ImageModel = chatmodels.IMAGE_MODEL_DALL_E_2
-		res = alexa.NewResponse("Chat Models", "ok", false)
+		res = alexa.NewResponse("Image Models", "ok", false)
+		return
 	case "which":
-		res = alexa.NewResponse("Chat Models", fmt.Sprintf("I am using the model %s", h.Model.String()), false)
+		res = alexa.NewResponse("Chat Models", fmt.Sprintf("I am using the text-model %s and image-model %s", h.Model.String(), h.ImageModel.String()), false)
 		return
 	default:
 		res = alexa.NewResponse(
-			"Chat Models",
-			fmt.Sprintf("The avaliable chat models are \n - %s", strings.Join(chatmodels.AvaliableModels, "\n - ")),
+			"Models",
+			fmt.Sprintf("The avaliable chat models are \n - %s and image models %s", strings.Join(chatmodels.AvaliableModels, "\n - "), strings.Join(chatmodels.ImageModels, "\n - ")),
 			false,
 		)
 		return

--- a/internal/api/response.go
+++ b/internal/api/response.go
@@ -53,7 +53,7 @@ response:
 	}
 
 	switch response.Model {
-	case chatmodels.IMAGE_MODEL_STABLE_DIFFUSION.String():
+	case chatmodels.IMAGE_MODEL_STABLE_DIFFUSION.String(), chatmodels.OPENAI_IMAGE_MODEL_DALL_E_2, chatmodels.OPENAI_IMAGE_MODEL_DALL_E_3:
 		res = alexa.NewImageResponse(
 			"Response",
 			fmt.Sprintf("your generated image took %s seconds to fetch", response.TimeDiff),
@@ -89,5 +89,4 @@ response:
 	}
 
 	return
-
 }

--- a/internal/dom/chatmodels/models.go
+++ b/internal/dom/chatmodels/models.go
@@ -33,12 +33,14 @@ var AvaliableModels = []string{
 
 var ImageModels = []string{
 	IMAGE_MODEL_STABLE_DIFFUSION.String(),
+	IMAGE_MODEL_DALL_E_3.String(),
 	IMAGE_MODEL_DALL_E_2.String(),
 }
 
 var StrToImageModel = map[string]ImageModel{
 	IMAGE_MODEL_STABLE_DIFFUSION.String(): IMAGE_MODEL_STABLE_DIFFUSION,
 	IMAGE_MODEL_DALL_E_2.String():         IMAGE_MODEL_DALL_E_2,
+	IMAGE_MODEL_DALL_E_3.String():         IMAGE_MODEL_DALL_E_3,
 }
 
 func (c ChatModel) String() string {


### PR DESCRIPTION
This pull request includes updates to the handling of image models in the API, specifically adding support for a new image model and improving the response messages. The most important changes include updating the model handling logic, adding a new image model, and updating the response format.

Updates to model handling logic:

* [`internal/api/model.go`](diffhunk://#diff-947d6fa8563714844f3b89c8b942919c354f8f36c78d5c829e15c7586daec3ccL43-R59): Changed the response messages for image models to correctly refer to them as "Image Models" instead of "Chat Models". Also updated the "which" case to include both text and image models in the response.

Addition of new image model:

* [`internal/dom/chatmodels/models.go`](diffhunk://#diff-0771410d41af31a88aa5f5b273b1344d972ecdbdc4c0daf157f09ec24258eb62R36-R43): Added `IMAGE_MODEL_DALL_E_3` to the list of available image models and updated the `StrToImageModel` map accordingly.

Updates to response format:

* [`internal/api/response.go`](diffhunk://#diff-0bf8ef2a18cc7d244a3344634f7efc9eb8e6aed6f42c677481881ab675d8d39bL56-R56): Added support for `IMAGE_MODEL_DALL_E_3` in the response handling, ensuring that the correct response is generated for this new model.
* [`internal/api/response.go`](diffhunk://#diff-0bf8ef2a18cc7d244a3344634f7efc9eb8e6aed6f42c677481881ab675d8d39bL92): Removed an unnecessary empty line at the end of the function.