### PR TITLE
fix: dall-e parameters & default image model set to stable diffusion

### DIFF
--- a/cmd/alexa/main.go
+++ b/cmd/alexa/main.go
@@ -27,6 +27,7 @@ func main() {
 		PollDelay:      pollDelay,
 		Logger:         logger,
 		Model:          chatmodels.CHAT_MODEL_GPT,
+		ImageModel:     chatmodels.IMAGE_MODEL_STABLE_DIFFUSION,
 	}
 	lambda.Start(h.Invoke)
 }

--- a/internal/dom/chatmodels/gpt_api.go
+++ b/internal/dom/chatmodels/gpt_api.go
@@ -47,8 +47,9 @@ func (api *OpenAIApiClient) GenerateImage(ctx context.Context, prompt string, mo
 	req := openai.ImageRequest{
 		Model:          model,
 		Prompt:         prompt,
-		Size:           openai.CreateImageSize256x256,
+		Size:           openai.CreateImageSize1024x1024,
 		ResponseFormat: openai.CreateImageResponseFormatB64JSON,
+		Quality:        "standard",
 		N:              1,
 	}
 


### PR DESCRIPTION
This pull request includes enhancements to the image generation functionality in the `cmd/alexa` and `internal/dom/chatmodels` directories. The key changes involve adding support for a new image model and improving the quality and size of generated images.

Enhancements to image generation:

* [`cmd/alexa/main.go`](diffhunk://#diff-f354f33e02ff8e6e28a420758c152fce25d4561930f1f2137c41ba2edf06696cR30): Added support for the `chatmodels.IMAGE_MODEL_STABLE_DIFFUSION` image model in the main function.

Improvements to image request parameters:

* [`internal/dom/chatmodels/gpt_api.go`](diffhunk://#diff-ccec1e3b71b06199fbf845b4269ae44b5dddc54c48305015d511486d611f1f7cL50-R52): Changed the image size from `256x256` to `1024x1024` and added a new `Quality` parameter set to "standard" in the `GenerateImage` function.