### PR TITLE
feat: multi-user support

### DIFF
--- a/cmd/alexa/main.go
+++ b/cmd/alexa/main.go
@@ -23,6 +23,7 @@ func main() {
 	pollDelay, _ := strconv.Atoi(os.Getenv("POLL_DELAY"))
 
 	h := api.Handler{
+		UserCache:       &api.UserCache{Data: make(map[string]*chatmodels.LastResponse)},
 		ChatGptService:  svc,
 		RequestsQueue:   queue.NewQueue(os.Getenv("REQUESTS_QUEUE_URI")),
 		ResponsesQueue:  queue.NewQueue(os.Getenv("RESPONSES_QUEUE_URI")),

--- a/cmd/sqs/main.go
+++ b/cmd/sqs/main.go
@@ -99,6 +99,7 @@ respond:
 		Model:          req.Model.String(),
 		ImagesResponse: imagesResponse,
 		Error:          errorMsg,
+		UserID:         req.UserID,
 	}
 
 	// override the model if image model was set

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -24,13 +24,18 @@ var (
 func TestLaunchIntent(t *testing.T) {
 	mockChatGptService := &chatmodels.MockClient{}
 	h := &Handler{
+		UserCache:      &UserCache{Data: make(map[string]*chatmodels.LastResponse)},
 		ChatGptService: mockChatGptService,
 		Logger:         logger,
 	}
 
 	req := alexa.Request{
 		Version: "",
-		Session: alexa.Session{},
+		Session: alexa.Session{
+			User: alexa.User{
+				UserID: "123",
+			},
+		},
 		Body: alexa.ReqBody{
 			Type: alexa.LaunchRequestType,
 		},
@@ -45,6 +50,7 @@ func TestLaunchIntent(t *testing.T) {
 func TestFallbackIntent(t *testing.T) {
 	mockChatGptService := &chatmodels.MockClient{}
 	h := &Handler{
+		UserCache:      &UserCache{Data: make(map[string]*chatmodels.LastResponse)},
 		ChatGptService: mockChatGptService,
 		Logger:         logger,
 		Model:          chatmodels.CHAT_MODEL_GPT,
@@ -52,7 +58,11 @@ func TestFallbackIntent(t *testing.T) {
 
 	req := alexa.Request{
 		Version: "",
-		Session: alexa.Session{},
+		Session: alexa.Session{
+			User: alexa.User{
+				UserID: "123",
+			},
+		},
 		Body: alexa.ReqBody{
 			Intent: alexa.Intent{
 				Name: alexa.FallbackIntent,
@@ -81,11 +91,12 @@ func TestAutoCompleteIntent(t *testing.T) {
 	mockRequestsQueue.On("PushMessage", mock.Anything, mock.Anything).Return(nil)
 
 	mockResponsesQueue := &queue.MockQueue{}
-	queueResponse := chatmodels.LastResponse{Response: "chimney", Model: chatmodels.CHAT_MODEL_GPT.String(), TimeDiff: "1s"}
+	queueResponse := chatmodels.LastResponse{Response: "chimney", Model: chatmodels.CHAT_MODEL_GPT.String(), TimeDiff: "1s", UserID: "123"}
 	jsonResp := utils.ToJSON(queueResponse)
 	mockResponsesQueue.On("PullMessage", mock.Anything, mock.Anything).Return([]byte(jsonResp), nil)
 
 	h := &Handler{
+		UserCache:      &UserCache{Data: make(map[string]*chatmodels.LastResponse)},
 		ChatGptService: mockChatGptService,
 		ResponsesQueue: mockResponsesQueue,
 		RequestsQueue:  mockRequestsQueue,
@@ -95,7 +106,11 @@ func TestAutoCompleteIntent(t *testing.T) {
 
 	req := alexa.Request{
 		Version: "",
-		Session: alexa.Session{},
+		Session: alexa.Session{
+			User: alexa.User{
+				UserID: "123",
+			},
+		},
 		Body: alexa.ReqBody{
 			Intent: alexa.Intent{
 				Name: "AutoCompleteIntent",
@@ -127,14 +142,18 @@ func TestImageIntent(t *testing.T) {
 	mockRequestsQueue.On("PushMessage", mock.Anything, mock.Anything).Return(nil)
 
 	mockResponsesQueue := &queue.MockQueue{}
-	queueResponse := chatmodels.LastResponse{Response: "", Model: chatmodels.IMAGE_MODEL_STABLE_DIFFUSION.String(), TimeDiff: "1", ImagesResponse: []string{
-		smallImageUrl,
-		largeImageUrl,
-	}}
+	queueResponse := chatmodels.LastResponse{
+		Response:       "",
+		Model:          chatmodels.IMAGE_MODEL_STABLE_DIFFUSION.String(),
+		TimeDiff:       "1",
+		ImagesResponse: []string{smallImageUrl, largeImageUrl},
+		UserID:         "123",
+	}
 	jsonResp := utils.ToJSON(queueResponse)
 	mockResponsesQueue.On("PullMessage", mock.Anything, mock.Anything).Return([]byte(jsonResp), nil)
 
 	h := &Handler{
+		UserCache:      &UserCache{Data: make(map[string]*chatmodels.LastResponse)},
 		ChatGptService: mockChatGptService,
 		ResponsesQueue: mockResponsesQueue,
 		RequestsQueue:  mockRequestsQueue,
@@ -144,7 +163,11 @@ func TestImageIntent(t *testing.T) {
 
 	req := alexa.Request{
 		Version: "",
-		Session: alexa.Session{},
+		Session: alexa.Session{
+			User: alexa.User{
+				UserID: "123",
+			},
+		},
 		Body: alexa.ReqBody{
 			Intent: alexa.Intent{
 				Name: "ImageIntent",
@@ -175,11 +198,12 @@ func TestImageIntentFailedToGenerateImagesResponse(t *testing.T) {
 	mockRequestsQueue.On("PushMessage", mock.Anything, mock.Anything).Return(nil)
 
 	mockResponsesQueue := &queue.MockQueue{}
-	queueResponse := chatmodels.LastResponse{Error: "image API failed", Model: chatmodels.IMAGE_MODEL_STABLE_DIFFUSION.String(), TimeDiff: "1", ImagesResponse: []string{}}
+	queueResponse := chatmodels.LastResponse{Error: "image API failed", Model: chatmodels.IMAGE_MODEL_STABLE_DIFFUSION.String(), TimeDiff: "1", ImagesResponse: []string{}, UserID: "123"}
 	jsonResp := utils.ToJSON(queueResponse)
 	mockResponsesQueue.On("PullMessage", mock.Anything, mock.Anything).Return([]byte(jsonResp), nil)
 
 	h := &Handler{
+		UserCache:      &UserCache{Data: make(map[string]*chatmodels.LastResponse)},
 		ChatGptService: mockChatGptService,
 		ResponsesQueue: mockResponsesQueue,
 		RequestsQueue:  mockRequestsQueue,
@@ -189,7 +213,11 @@ func TestImageIntentFailedToGenerateImagesResponse(t *testing.T) {
 
 	req := alexa.Request{
 		Version: "",
-		Session: alexa.Session{},
+		Session: alexa.Session{
+			User: alexa.User{
+				UserID: "123",
+			},
+		},
 		Body: alexa.ReqBody{
 			Intent: alexa.Intent{
 				Name: "ImageIntent",
@@ -217,6 +245,7 @@ func TestRandomIntent(t *testing.T) {
 	mockChatGptService.On("TextGeneration", mock.Anything, mock.Anything, mock.Anything).Return("santa fell down the chimney", nil)
 
 	h := &Handler{
+		UserCache:      &UserCache{Data: make(map[string]*chatmodels.LastResponse)},
 		ChatGptService: mockChatGptService,
 		Logger:         logger,
 		Model:          chatmodels.CHAT_MODEL_GPT,
@@ -224,7 +253,11 @@ func TestRandomIntent(t *testing.T) {
 
 	req := alexa.Request{
 		Version: "",
-		Session: alexa.Session{},
+		Session: alexa.Session{
+			User: alexa.User{
+				UserID: "123",
+			},
+		},
 		Body: alexa.ReqBody{
 			Intent: alexa.Intent{
 				Name: alexa.RandomFactIntent,
@@ -253,6 +286,7 @@ func TestLastResponseIntent(t *testing.T) {
 		Model:    chatmodels.CHAT_MODEL_GPT.String(),
 		Response: "chimney",
 		TimeDiff: time.Since(time.Now().Add(-time.Second)).String(),
+		UserID:   "123",
 	}
 
 	jsonResp := utils.ToJSON(queueResponse)
@@ -260,7 +294,7 @@ func TestLastResponseIntent(t *testing.T) {
 
 	mockChatGptService := &chatmodels.MockClient{}
 	h := &Handler{
-		lastResponse:   &queueResponse,
+		UserCache:      &UserCache{Data: make(map[string]*chatmodels.LastResponse)},
 		ChatGptService: mockChatGptService,
 		ResponsesQueue: mockResponsesQueue,
 		Logger:         logger,
@@ -268,7 +302,11 @@ func TestLastResponseIntent(t *testing.T) {
 
 	req := alexa.Request{
 		Version: "",
-		Session: alexa.Session{},
+		Session: alexa.Session{
+			User: alexa.User{
+				UserID: "123",
+			},
+		},
 		Body: alexa.ReqBody{
 			Intent: alexa.Intent{
 				Name: alexa.LastResponseIntent,
@@ -293,6 +331,7 @@ func TestLastResponseIntent(t *testing.T) {
 func TestStopIntent(t *testing.T) {
 	mockChatGptService := &chatmodels.MockClient{}
 	h := &Handler{
+		UserCache:      &UserCache{Data: make(map[string]*chatmodels.LastResponse)},
 		ChatGptService: mockChatGptService,
 		Logger:         logger,
 		Model:          chatmodels.CHAT_MODEL_GPT,
@@ -300,7 +339,11 @@ func TestStopIntent(t *testing.T) {
 
 	req := alexa.Request{
 		Version: "",
-		Session: alexa.Session{},
+		Session: alexa.Session{
+			User: alexa.User{
+				UserID: "123",
+			},
+		},
 		Body: alexa.ReqBody{
 			Intent: alexa.Intent{
 				Name: alexa.StopIntent,
@@ -319,6 +362,7 @@ func TestStopIntent(t *testing.T) {
 func TestCancelIntent(t *testing.T) {
 	mockChatGptService := &chatmodels.MockClient{}
 	h := &Handler{
+		UserCache:      &UserCache{Data: make(map[string]*chatmodels.LastResponse)},
 		ChatGptService: mockChatGptService,
 		Logger:         logger,
 		Model:          chatmodels.CHAT_MODEL_GPT,
@@ -326,7 +370,11 @@ func TestCancelIntent(t *testing.T) {
 
 	req := alexa.Request{
 		Version: "",
-		Session: alexa.Session{},
+		Session: alexa.Session{
+			User: alexa.User{
+				UserID: "123",
+			},
+		},
 		Body: alexa.ReqBody{
 			Intent: alexa.Intent{
 				Name: alexa.CancelIntent,
@@ -345,6 +393,7 @@ func TestCancelIntent(t *testing.T) {
 func TestHelpIntent(t *testing.T) {
 	mockChatGptService := &chatmodels.MockClient{}
 	h := &Handler{
+		UserCache:      &UserCache{Data: make(map[string]*chatmodels.LastResponse)},
 		ChatGptService: mockChatGptService,
 		Logger:         logger,
 		Model:          chatmodels.CHAT_MODEL_GPT,
@@ -352,7 +401,11 @@ func TestHelpIntent(t *testing.T) {
 
 	req := alexa.Request{
 		Version: "",
-		Session: alexa.Session{},
+		Session: alexa.Session{
+			User: alexa.User{
+				UserID: "123",
+			},
+		},
 		Body: alexa.ReqBody{
 			Intent: alexa.Intent{
 				Name: alexa.HelpIntent,
@@ -375,6 +428,7 @@ func TestHelpIntent(t *testing.T) {
 func TestModelIntentGPT(t *testing.T) {
 	mockChatGptService := &chatmodels.MockClient{}
 	h := &Handler{
+		UserCache:      &UserCache{Data: make(map[string]*chatmodels.LastResponse)},
 		ChatGptService: mockChatGptService,
 		Logger:         logger,
 		Model:          chatmodels.CHAT_MODEL_GPT,
@@ -382,7 +436,11 @@ func TestModelIntentGPT(t *testing.T) {
 
 	req := alexa.Request{
 		Version: "",
-		Session: alexa.Session{},
+		Session: alexa.Session{
+			User: alexa.User{
+				UserID: "123",
+			},
+		},
 		Body: alexa.ReqBody{
 			Intent: alexa.Intent{
 				Name: alexa.ModelIntent,
@@ -412,6 +470,7 @@ func TestModelIntentGPT(t *testing.T) {
 func TestModelIntentGemini(t *testing.T) {
 	mockChatGptService := &chatmodels.MockClient{}
 	h := &Handler{
+		UserCache:      &UserCache{Data: make(map[string]*chatmodels.LastResponse)},
 		ChatGptService: mockChatGptService,
 		Logger:         logger,
 		Model:          chatmodels.CHAT_MODEL_GEMINI,
@@ -419,7 +478,11 @@ func TestModelIntentGemini(t *testing.T) {
 
 	req := alexa.Request{
 		Version: "",
-		Session: alexa.Session{},
+		Session: alexa.Session{
+			User: alexa.User{
+				UserID: "123",
+			},
+		},
 		Body: alexa.ReqBody{
 			Intent: alexa.Intent{
 				Name: alexa.ModelIntent,
@@ -449,6 +512,7 @@ func TestModelIntentGemini(t *testing.T) {
 func TestUnsupportedIntent(t *testing.T) {
 	mockChatGptService := &chatmodels.MockClient{}
 	h := &Handler{
+		UserCache:      &UserCache{Data: make(map[string]*chatmodels.LastResponse)},
 		ChatGptService: mockChatGptService,
 		Logger:         logger,
 		Model:          chatmodels.CHAT_MODEL_GPT,
@@ -456,7 +520,11 @@ func TestUnsupportedIntent(t *testing.T) {
 
 	req := alexa.Request{
 		Version: "",
-		Session: alexa.Session{},
+		Session: alexa.Session{
+			User: alexa.User{
+				UserID: "123",
+			},
+		},
 		Body: alexa.ReqBody{
 			Intent: alexa.Intent{
 				Name: "AMAZON.random",
@@ -479,6 +547,7 @@ func TestPurgeIntent(t *testing.T) {
 
 	mockChatGptService := &chatmodels.MockClient{}
 	h := &Handler{
+		UserCache:      &UserCache{Data: make(map[string]*chatmodels.LastResponse)},
 		ChatGptService: mockChatGptService,
 		Logger:         logger,
 		Model:          chatmodels.CHAT_MODEL_GEMINI,
@@ -487,7 +556,11 @@ func TestPurgeIntent(t *testing.T) {
 
 	req := alexa.Request{
 		Version: "",
-		Session: alexa.Session{},
+		Session: alexa.Session{
+			User: alexa.User{
+				UserID: "123",
+			},
+		},
 		Body: alexa.ReqBody{
 			Intent: alexa.Intent{
 				Name: alexa.PurgeIntent,

--- a/internal/dom/chatmodels/queue.go
+++ b/internal/dom/chatmodels/queue.go
@@ -7,6 +7,7 @@ type LastResponse struct {
 	Model          string   `json:"model"`
 	ImagesResponse []string `json:"images_responses"`
 	Error          string   `json:"error_message"`
+	UserID         string   `json:"user_id"`
 }
 
 type Request struct {
@@ -15,4 +16,5 @@ type Request struct {
 	SourceLanguage string      `json:"source_language,omitempty"`
 	Model          ChatModel   `json:"model"`
 	ImageModel     *ImageModel `json:"image_model"`
+	UserID         string      `json:"user_id"`
 }

--- a/internal/pkg/alexa/request.go
+++ b/internal/pkg/alexa/request.go
@@ -15,6 +15,11 @@ type Request struct {
 	Context Context `json:"context"`
 }
 
+type User struct {
+	UserID      string `json:"userId"`
+	AccessToken string `json:"accessToken,omitempty"`
+}
+
 // Session represents the Alexa skill session.
 type Session struct {
 	New         bool   `json:"new"`
@@ -23,10 +28,7 @@ type Session struct {
 		ApplicationID string `json:"applicationId"`
 	} `json:"application"`
 	Attributes map[string]interface{} `json:"attributes"`
-	User       struct {
-		UserID      string `json:"userId"`
-		AccessToken string `json:"accessToken,omitempty"`
-	} `json:"user"`
+	User       User                   `json:"user"`
 }
 
 // Context represents the Alexa skill request context.


### PR DESCRIPTION
This pull request implements user-specific caching for responses in the Alexa ChatGPT service by introducing a `UserCache` structure. The main changes include modifying the handler to utilize the `UserCache` for storing and retrieving user-specific responses, and updating the associated tests to accommodate these changes.

Key changes:

### User-specific caching:
* [`internal/api/handler.go`](diffhunk://#diff-4557c0feb4807d067dd963ec1a7d19ad62c17d2ebce2afb769ca83c6c9c58250R18-L20): Introduced `UserCache` struct with synchronization mechanisms and integrated it into the `Handler` struct to replace the previous `lastResponse` field. [[1]](diffhunk://#diff-4557c0feb4807d067dd963ec1a7d19ad62c17d2ebce2afb769ca83c6c9c58250R18-L20) [[2]](diffhunk://#diff-4557c0feb4807d067dd963ec1a7d19ad62c17d2ebce2afb769ca83c6c9c58250R34)
* [`cmd/alexa/main.go`](diffhunk://#diff-f354f33e02ff8e6e28a420758c152fce25d4561930f1f2137c41ba2edf06696cR26): Updated the handler initialization to include the `UserCache`.

### Handler modifications:
* [`internal/api/handler.go`](diffhunk://#diff-4557c0feb4807d067dd963ec1a7d19ad62c17d2ebce2afb769ca83c6c9c58250R44-R48): Updated the `DispatchIntents` method to use `UserCache` for storing and retrieving user-specific responses based on the `userID` from the request session. [[1]](diffhunk://#diff-4557c0feb4807d067dd963ec1a7d19ad62c17d2ebce2afb769ca83c6c9c58250R44-R48) [[2]](diffhunk://#diff-4557c0feb4807d067dd963ec1a7d19ad62c17d2ebce2afb769ca83c6c9c58250L62-R73) [[3]](diffhunk://#diff-4557c0feb4807d067dd963ec1a7d19ad62c17d2ebce2afb769ca83c6c9c58250L81-R92) [[4]](diffhunk://#diff-4557c0feb4807d067dd963ec1a7d19ad62c17d2ebce2afb769ca83c6c9c58250L91-R102) [[5]](diffhunk://#diff-4557c0feb4807d067dd963ec1a7d19ad62c17d2ebce2afb769ca83c6c9c58250L103-R114) [[6]](diffhunk://#diff-4557c0feb4807d067dd963ec1a7d19ad62c17d2ebce2afb769ca83c6c9c58250L157-R168) [[7]](diffhunk://#diff-4557c0feb4807d067dd963ec1a7d19ad62c17d2ebce2afb769ca83c6c9c58250L168-R179)

### Test updates:
* [`internal/api/handler_test.go`](diffhunk://#diff-efb283f422468cb14dcc4eb52ffb63dbe8693643dd8cb9f9958bd928a43cab22R27-R38): Modified test cases to initialize the `Handler` with `UserCache` and include `userID` in the `LastResponse` and request session. [[1]](diffhunk://#diff-efb283f422468cb14dcc4eb52ffb63dbe8693643dd8cb9f9958bd928a43cab22R27-R38) [[2]](diffhunk://#diff-efb283f422468cb14dcc4eb52ffb63dbe8693643dd8cb9f9958bd928a43cab22R53-R65) [[3]](diffhunk://#diff-efb283f422468cb14dcc4eb52ffb63dbe8693643dd8cb9f9958bd928a43cab22L84-R99) [[4]](diffhunk://#diff-efb283f422468cb14dcc4eb52ffb63dbe8693643dd8cb9f9958bd928a43cab22L98-R113) [[5]](diffhunk://#diff-efb283f422468cb14dcc4eb52ffb63dbe8693643dd8cb9f9958bd928a43cab22L130-R156) [[6]](diffhunk://#diff-efb283f422468cb14dcc4eb52ffb63dbe8693643dd8cb9f9958bd928a43cab22L147-R170) [[7]](diffhunk://#diff-efb283f422468cb14dcc4eb52ffb63dbe8693643dd8cb9f9958bd928a43cab22L178-R206) [[8]](diffhunk://#diff-efb283f422468cb14dcc4eb52ffb63dbe8693643dd8cb9f9958bd928a43cab22L192-R220) [[9]](diffhunk://#diff-efb283f422468cb14dcc4eb52ffb63dbe8693643dd8cb9f9958bd928a43cab22R248-R260) [[10]](diffhunk://#diff-efb283f422468cb14dcc4eb52ffb63dbe8693643dd8cb9f9958bd928a43cab22R289-R309) [[11]](diffhunk://#diff-efb283f422468cb14dcc4eb52ffb63dbe8693643dd8cb9f9958bd928a43cab22R334-R346) [[12]](diffhunk://#diff-efb283f422468cb14dcc4eb52ffb63dbe8693643dd8cb9f9958bd928a43cab22R365-R377) [[13]](diffhunk://#diff-efb283f422468cb14dcc4eb52ffb63dbe8693643dd8cb9f9958bd928a43cab22R396-R408) [[14]](diffhunk://#diff-efb283f422468cb14dcc4eb52ffb63dbe8693643dd8cb9f9958bd928a43cab22R431-R443) [[15]](diffhunk://#diff-efb283f422468cb14dcc4eb52ffb63dbe8693643dd8cb9f9958bd928a43cab22R473-R485) [[16]](diffhunk://#diff-efb283f422468cb14dcc4eb52ffb63dbe8693643dd8cb9f9958bd928a43cab22R515-R527) [[17]](diffhunk://#diff-efb283f422468cb14dcc4eb52ffb63dbe8693643dd8cb9f9958bd928a43cab22R550) [[18]](diffhunk://#diff-efb283f422468cb14dcc4eb52ffb63dbe8693643dd8cb9f9958bd928a43cab22L490-R563)

### Additional imports:
* [`internal/api/handler.go`](diffhunk://#diff-4557c0feb4807d067dd963ec1a7d19ad62c17d2ebce2afb769ca83c6c9c58250R9): Added the `sync` package for read-write lock implementation in `UserCache`.