### PR TITLE
fix: missing cloud-platform auth scope

### DIFF
--- a/internal/dom/chatmodels/gemini_api.go
+++ b/internal/dom/chatmodels/gemini_api.go
@@ -19,7 +19,7 @@ type GeminiApiClient struct {
 func NewGeminiApiClient(token string) *GeminiApiClient {
 	tkn, _ := base64.StdEncoding.DecodeString(token)
 
-	creds, err := google.CredentialsFromJSON(context.Background(), tkn, "https://www.googleapis.com/auth/generative-language")
+	creds, err := google.CredentialsFromJSON(context.Background(), tkn, "https://www.googleapis.com/auth/generative-language", "https://www.googleapis.com/auth/cloud-platform")
 	if err != nil {
 		slog.With("error", err).Error("failed to init google creds")
 	}


### PR DESCRIPTION
This pull request includes a change to the `GeminiApiClient` in the `internal/dom/chatmodels/gemini_api.go` file to expand the scope of Google credentials. The most important change is:

* [`internal/dom/chatmodels/gemini_api.go`](diffhunk://#diff-e462e54657a8bcf2857834eb35a42d3d4e3ad44eb5358ee8108d533c83b66e24L22-R22): Added the `https://www.googleapis.com/auth/cloud-platform` scope to the Google credentials initialization.