### PR TITLE
feat: use model gemini-2.0-flash-exp for the vertex api

### DIFF
--- a/internal/dom/chatmodels/gemini_api.go
+++ b/internal/dom/chatmodels/gemini_api.go
@@ -10,7 +10,7 @@ import (
 	"google.golang.org/genai"
 )
 
-const MODEL string = "gemini-1.0-pro"
+const VERTEX_MODEL string = "gemini-2.0-flash-exp"
 
 type GeminiApiClient struct {
 	credentials *google.Credentials
@@ -38,7 +38,7 @@ func (api *GeminiApiClient) GenerateText(ctx context.Context, prompt string) (st
 		return "", err
 	}
 
-	res, err := client.Models.GenerateContent(ctx, MODEL, genai.Text(prompt), nil)
+	res, err := client.Models.GenerateContent(ctx, VERTEX_MODEL, genai.Text(prompt), nil)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This pull request includes changes to the `internal/dom/chatmodels/gemini_api.go` file to update the model used for generating text. The most important changes include updating the model constant and modifying the `GenerateText` method to use the new model.

Model update:

* [`internal/dom/chatmodels/gemini_api.go`](diffhunk://#diff-e462e54657a8bcf2857834eb35a42d3d4e3ad44eb5358ee8108d533c83b66e24L13-R13): Changed the model constant from `"gemini-1.0-pro"` to `"gemini-2.0-flash-exp"`.

Method modification:

* [`internal/dom/chatmodels/gemini_api.go`](diffhunk://#diff-e462e54657a8bcf2857834eb35a42d3d4e3ad44eb5358ee8108d533c83b66e24L41-R41): Updated the `GenerateText` method to use the new `VERTEX_MODEL` constant instead of the old `MODEL` constant.