### PR TITLE
feat: use Llama 3.3-70b-Instruct

### DIFF
--- a/internal/dom/chatmodels/cloudflare_ai_worker_api.go
+++ b/internal/dom/chatmodels/cloudflare_ai_worker_api.go
@@ -13,22 +13,23 @@ import (
 )
 
 const (
-	CF_LLAMA_2_7B_CHAT_INT8_MODEL  = "@cf/meta/llama-2-7b-chat-int8"
-	CF_LLAMA_3_8B_INSTRUCT_MODEL   = "@cf/meta/llama-3-8b-instruct"
-	CF_LLAMA_3_1_INSTRUCT_MODEL    = "@cf/meta/llama-3.1-8b-instruct"
-	CF_LLAMA_3_2_3B_INSTRUCT_MODEL = "@cf/meta/llama-3.2-3b-instruct"
-	CF_SQL_MODEL                   = "@cf/defog/sqlcoder-7b-2"
-	CF_AWQ_MODEL                   = "@hf/thebloke/llama-2-13b-chat-awq"
-	CF_OPEN_CHAT_MODEL             = "@cf/openchat/openchat-3.5-0106"
-	CF_STABLE_DIFFUSION            = "@cf/stabilityai/stable-diffusion-xl-base-1.0"
-	CF_META_TRANSLATION_MODEL      = "@cf/meta/m2m100-1.2b"
-	CF_QWEN_MODEL                  = "@cf/qwen/qwen1.5-1.8b-chat"
+	CF_LLAMA_2_7B_CHAT_INT8_MODEL   = "@cf/meta/llama-2-7b-chat-int8"
+	CF_LLAMA_3_8B_INSTRUCT_MODEL    = "@cf/meta/llama-3-8b-instruct"
+	CF_LLAMA_3_1_INSTRUCT_MODEL     = "@cf/meta/llama-3.1-8b-instruct"
+	CF_LLAMA_3_2_3B_INSTRUCT_MODEL  = "@cf/meta/llama-3.2-3b-instruct"
+	CF_LLAMA_3_3_70B_INSTRUCT_MODEL = "@cf/meta/llama-3.3-70b-instruct"
+	CF_SQL_MODEL                    = "@cf/defog/sqlcoder-7b-2"
+	CF_AWQ_MODEL                    = "@hf/thebloke/llama-2-13b-chat-awq"
+	CF_OPEN_CHAT_MODEL              = "@cf/openchat/openchat-3.5-0106"
+	CF_STABLE_DIFFUSION             = "@cf/stabilityai/stable-diffusion-xl-base-1.0"
+	CF_META_TRANSLATION_MODEL       = "@cf/meta/m2m100-1.2b"
+	CF_QWEN_MODEL                   = "@cf/qwen/qwen1.5-1.8b-chat"
 )
 
 var CHAT_MODEL_TO_CF_MODEL = map[ChatModel]string{
 	CHAT_MODEL_SQL:          CF_SQL_MODEL,
 	CHAT_MODEL_AWQ:          CF_AWQ_MODEL,
-	CHAT_MODEL_META:         CF_LLAMA_3_2_3B_INSTRUCT_MODEL,
+	CHAT_MODEL_META:         CF_LLAMA_3_3_70B_INSTRUCT_MODEL,
 	CHAT_MODEL_OPEN:         CF_OPEN_CHAT_MODEL,
 	CHAT_MODEL_TRANSLATIONS: CF_META_TRANSLATION_MODEL,
 	CHAT_MODEL_QWEN:         CF_QWEN_MODEL,


### PR DESCRIPTION
This pull request includes updates to the `internal/dom/chatmodels/cloudflare_ai_worker_api.go` file to add a new AI model and update the model mapping.

Key changes include:

* Added a new AI model constant `CF_LLAMA_3_3_70B_INSTRUCT_MODEL` to the list of available models.
* Updated the `CHAT_MODEL_META` mapping to use the new `CF_LLAMA_3_3_70B_INSTRUCT_MODEL` instead of the previous `CF_LLAMA_3_2_3B_INSTRUCT_MODEL`.