### PR TITLE
fix: use llama-3.3-70b-instruct-fp8-fas model

### DIFF
--- a/internal/dom/chatmodels/cloudflare_ai_worker_api.go
+++ b/internal/dom/chatmodels/cloudflare_ai_worker_api.go
@@ -17,7 +17,7 @@ const (
 	CF_LLAMA_3_8B_INSTRUCT_MODEL    = "@cf/meta/llama-3-8b-instruct"
 	CF_LLAMA_3_1_INSTRUCT_MODEL     = "@cf/meta/llama-3.1-8b-instruct"
 	CF_LLAMA_3_2_3B_INSTRUCT_MODEL  = "@cf/meta/llama-3.2-3b-instruct"
-	CF_LLAMA_3_3_70B_INSTRUCT_MODEL = "@cf/meta/llama-3.3-70b-instruct"
+	CF_LLAMA_3_3_70B_INSTRUCT_MODEL = "@cf/meta/llama-3.3-70b-instruct-fp8-fas"
 	CF_SQL_MODEL                    = "@cf/defog/sqlcoder-7b-2"
 	CF_AWQ_MODEL                    = "@hf/thebloke/llama-2-13b-chat-awq"
 	CF_OPEN_CHAT_MODEL              = "@cf/openchat/openchat-3.5-0106"


### PR DESCRIPTION
This pull request includes a minor but important change to the `internal/dom/chatmodels/cloudflare_ai_worker_api.go` file. The change updates the model identifier for the `CF_LLAMA_3_3_70B_INSTRUCT_MODEL` to use a new version with a different floating-point precision format.

* [`internal/dom/chatmodels/cloudflare_ai_worker_api.go`](diffhunk://#diff-076f13595a20e78219f971d316673955c4ace7764156b45bf047bad4ee591971L20-R20): Updated the `CF_LLAMA_3_3_70B_INSTRUCT_MODEL` to use the new identifier `@cf/meta/llama-3.3-70b-instruct-fp8-fas`.