### PR TITLE
feat: cloudflare via langchain package

### DIFF
--- a/internal/dom/chatmodels/api.go
+++ b/internal/dom/chatmodels/api.go
@@ -24,24 +24,42 @@ type GeminiAPI interface {
 }
 
 type CloudFlareAiWorkerAPI interface {
+	LlmModel
 	GenerateTextWithModel(context.Context, string, string) (string, error)
 	GenerateImage(ctx context.Context, prompt string, model string) ([]byte, error)
 	GenerateTranslation(ctx context.Context, req *GenerateTranslationRequest) (string, error)
+}
+
+
+
+
+type mockLlmModel struct {
+	llms.Model
+ 	mock.Mock
+}
+
+func (api *mockLlmModel) GenerateContent(ctx context.Context, messages []llms.MessageContent, options ...llms.CallOption) (content *llms.ContentResponse, err error) {
+	args := api.Called(ctx, messages, options)
+	if args.Get(0) != nil {
+		content = args.Get(0).(*llms.ContentResponse)
+	}
+	return content, args.Error(1)
 }
 
 type mockAPI struct {
 	mock.Mock
 }
 
-func (api *mockAPI) AutoComplete(ctx context.Context, prompt string) (res openai.ChatCompletionResponse, err error) {
-	args := api.Called(ctx, prompt)
-	res = args.Get(0).(openai.ChatCompletionResponse)
-	return res, args.Error(1)
-}
-
 func (api *mockAPI) GeminiChat(ctx context.Context, prompt string) (res *genai.GenerateContentResponse, err error) {
 	args := api.Called(ctx, prompt)
 	res = args.Get(0).(*genai.GenerateContentResponse)
+	return res, args.Error(1)
+}
+
+
+func (api *mockAPI) AutoComplete(ctx context.Context, prompt string) (res openai.ChatCompletionResponse, err error) {
+	args := api.Called(ctx, prompt)
+	res = args.Get(0).(openai.ChatCompletionResponse)
 	return res, args.Error(1)
 }
 

--- a/internal/dom/chatmodels/cloudflare_ai_worker_api.go
+++ b/internal/dom/chatmodels/cloudflare_ai_worker_api.go
@@ -6,10 +6,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"log/slog"
 	"net/http"
 
 	"github.com/jackmcguire1/alexa-chatgpt/internal/pkg/utils"
+	"github.com/tmc/langchaingo/llms"
+	"github.com/tmc/langchaingo/llms/cloudflare"
 )
 
 const (
@@ -66,60 +69,41 @@ type TranslateResponse struct {
 type CloudflareApiClient struct {
 	AccountID string
 	APIKey    string
+	Client    *cloudflare.LLM
 }
 
 func NewCloudflareApiClient(accountID, apiKey string) *CloudflareApiClient {
+
+	llm, err := cloudflare.New(
+		cloudflare.WithToken(apiKey),
+		cloudflare.WithAccountID(accountID),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	return &CloudflareApiClient{
 		AccountID: accountID,
 		APIKey:    apiKey,
+		Client:    llm,
 	}
 }
 
 func (api *CloudflareApiClient) GenerateTextWithModel(ctx context.Context, prompt string, model string) (string, error) {
-	url := fmt.Sprintf("https://api.cloudflare.com/client/v4/accounts/%s/ai/run/%s", api.AccountID, model)
-
-	payload := map[string]string{
-		"prompt": prompt,
+	content := []llms.MessageContent{
+		llms.TextParts(llms.ChatMessageTypeSystem, "Answer as if the user is asking a question"),
+		llms.TextParts(llms.ChatMessageTypeHuman, prompt),
 	}
-	jsonPayload, err := json.Marshal(payload)
+
+	completion, err := api.Client.GenerateContent(ctx, content, llms.WithModel(model))
 	if err != nil {
 		return "", err
 	}
-
-	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(jsonPayload))
-	if err != nil {
-		return "", err
-	}
-	req.Header.Set("Authorization", "Bearer "+api.APIKey)
-	req.Header.Set("Content-Type", "application/json")
-
-	client := &http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-
-	data, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", err
+	if len(completion.Choices) == 0 {
+		return "", fmt.Errorf("no choices in response from cloudflare")
 	}
 
-	var result *Response
-	err = json.Unmarshal(data, &result)
-	if err != nil {
-		return "", fmt.Errorf("failed to unmarshal cloudflare response body %s", string(data))
-	}
-
-	if !result.Success {
-		return "", fmt.Errorf("didn't get success from result %v http-status: %d", utils.ToJSON(result), resp.StatusCode)
-	}
-
-	if result.Result.Response == "" {
-		return "", fmt.Errorf("cloudflare ai worker model failed to generate text %w", MissingContentError)
-	}
-
-	return result.Result.Response, nil
+	return completion.Choices[0].Content, nil
 }
 
 func (api *CloudflareApiClient) GenerateImage(ctx context.Context, prompt string, model string) ([]byte, error) {

--- a/internal/dom/chatmodels/cloudflare_ai_worker_api.go
+++ b/internal/dom/chatmodels/cloudflare_ai_worker_api.go
@@ -90,20 +90,11 @@ func NewCloudflareApiClient(accountID, apiKey string) *CloudflareApiClient {
 }
 
 func (api *CloudflareApiClient) GenerateTextWithModel(ctx context.Context, prompt string, model string) (string, error) {
-	content := []llms.MessageContent{
-		llms.TextParts(llms.ChatMessageTypeSystem, "Answer as if the user is asking a question"),
-		llms.TextParts(llms.ChatMessageTypeHuman, prompt),
-	}
+	return llms.GenerateFromSinglePrompt(ctx, api.Client, prompt, llms.WithModel(model))
+}
 
-	completion, err := api.Client.GenerateContent(ctx, content, llms.WithModel(model))
-	if err != nil {
-		return "", err
-	}
-	if len(completion.Choices) == 0 {
-		return "", fmt.Errorf("no choices in response from cloudflare")
-	}
-
-	return completion.Choices[0].Content, nil
+func (api *CloudflareApiClient) GetModel() llms.Model {
+	return api.Client
 }
 
 func (api *CloudflareApiClient) GenerateImage(ctx context.Context, prompt string, model string) ([]byte, error) {

--- a/internal/dom/chatmodels/prompts.go
+++ b/internal/dom/chatmodels/prompts.go
@@ -10,23 +10,20 @@ func (client *Client) TextGeneration(ctx context.Context, prompt string, model C
 	switch model {
 	case CHAT_MODEL_GEMINI:
 		return client.GeminiAPI.GenerateText(ctx, prompt)
-	case CHAT_MODEL_META, CHAT_MODEL_SQL, CHAT_MODEL_OPEN, CHAT_MODEL_AWQ, CHAT_MODEL_QWEN:
-		return client.CloudflareApiClient.GenerateTextWithModel(ctx, prompt, CHAT_MODEL_TO_CF_MODEL[model])
-	case CHAT_MODEL_GPT, CHAT_MODEL_GPT_V4:
-		fallthrough
 	default:
-		return llms.GenerateFromSinglePrompt(ctx, client.GetLLmModel(model), prompt, llms.WithModel(CHAT_MODEL_TO_OPENAI_MODEL[model]))
+		model, opts := client.GetLLmModel(model)
+		return llms.GenerateFromSinglePrompt(ctx, model, prompt, opts...)
 	}
 }
 
-func (client *Client) GetLLmModel(model ChatModel) llms.Model {
+func (client *Client) GetLLmModel(model ChatModel) (llms.Model, []llms.CallOption){
 	switch model {
+	case CHAT_MODEL_META, CHAT_MODEL_SQL, CHAT_MODEL_OPEN, CHAT_MODEL_AWQ, CHAT_MODEL_QWEN:
+		return client.CloudflareApiClient.GetModel(), []llms.CallOption{llms.WithModel(CHAT_MODEL_TO_CF_MODEL[model])}
 	case CHAT_MODEL_GEMINI:
 		fallthrough
-	case CHAT_MODEL_META, CHAT_MODEL_SQL, CHAT_MODEL_OPEN, CHAT_MODEL_AWQ, CHAT_MODEL_QWEN:
-		fallthrough
 	default:
-		return client.GPTApi.GetModel()
+		return client.GPTApi.GetModel(), []llms.CallOption{llms.WithModel(CHAT_MODEL_TO_OPENAI_MODEL[model])}
 	}
 }
 


### PR DESCRIPTION
This pull request introduces significant changes to the `internal/dom/chatmodels/cloudflare_ai_worker_api.go` file, focusing on integrating the Cloudflare LLM client and refactoring the `GenerateTextWithModel` method to use this new client. The most important changes include importing new packages, updating the `CloudflareApiClient` struct, initializing the Cloudflare LLM client, and refactoring the text generation method.

Integration of Cloudflare LLM client:

* [`internal/dom/chatmodels/cloudflare_ai_worker_api.go`](diffhunk://#diff-076f13595a20e78219f971d316673955c4ace7764156b45bf047bad4ee591971R9-R15): Added imports for `log`, `github.com/tmc/langchaingo/llms`, and `github.com/tmc/langchaingo/llms/cloudflare`.

Refactoring for text generation:

* [`internal/dom/chatmodels/cloudflare_ai_worker_api.go`](diffhunk://#diff-076f13595a20e78219f971d316673955c4ace7764156b45bf047bad4ee591971R72-R106): Updated the `CloudflareApiClient` struct to include a `Client` field of type `*cloudflare.LLM`.
* [`internal/dom/chatmodels/cloudflare_ai_worker_api.go`](diffhunk://#diff-076f13595a20e78219f971d316673955c4ace7764156b45bf047bad4ee591971R72-R106): Modified the `NewCloudflareApiClient` function to initialize the Cloudflare LLM client and handle potential errors.
* [`internal/dom/chatmodels/cloudflare_ai_worker_api.go`](diffhunk://#diff-076f13595a20e78219f971d316673955c4ace7764156b45bf047bad4ee591971R72-R106): Refactored the `GenerateTextWithModel` method to use the Cloudflare LLM client for generating text, simplifying the payload and request handling.

https://github.com/jackmcguire1/alexa-chatgpt/issues/118